### PR TITLE
Update to Util.java to allow copying files larger 2GB

### DIFF
--- a/src/main/java/com/compomics/util/Util.java
+++ b/src/main/java/com/compomics/util/Util.java
@@ -765,7 +765,10 @@ public class Util {
         FileChannel inChannel = new FileInputStream(in).getChannel();
         FileChannel outChannel = new FileOutputStream(out).getChannel();
         try {
-            inChannel.transferTo(start, inChannel.size(), outChannel);
+            long bytesCopied = 0;
+            while (bytesCopied < in.length()) {
+                bytesCopied += inChannel.transferTo(start + bytesCopied, inChannel.size(), outChannel);
+            }
         } finally {
             if (inChannel != null) {
                 inChannel.close();


### PR DESCRIPTION
By default, `FileChannel.transferTo()` copies only 2GB of a file. To copy larger files, the method needs to be called several times. (Internally, `transferTo()` appears to be using a `MappedByteBuffer`, which is faster than other methods but limited to 2GB).

This should fix an issue with PeptideShaker/ZooDB.

See [ZooDB issue #122](https://github.com/tzaeschke/zoodb/issues/122)